### PR TITLE
Tower logic

### DIFF
--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -129,9 +129,11 @@ export default class Scheduler {
 
     private static partMap = {
         builder: [MOVE, WORK, CARRY],
+        claimer: [MOVE, CLAIM],
         hauler: [MOVE, CARRY, CARRY],
         worker: [MOVE, WORK, CARRY]
     };
+
     private static requisitionCreep(type: string, room: Room) {
         const parts = (this.partMap as any)[type];
         const spawner = room.find(FIND_MY_SPAWNS)

--- a/src/tasks/tower/universal.ts
+++ b/src/tasks/tower/universal.ts
@@ -2,31 +2,51 @@ import Task from '../task';
 
 /**
  * This task is assigned to creeps that transfer from containers to the spawn.
+ * He attac, he protec, and lastly he repair structures (in that order).
+ *
+ * This tower task prioritizes the following in the following order:
+ * 1. Attack any enemy creeps in range.
+ * 2. Heal any allied creeps in range.
+ * 3. Repair any structures in range.
  */
 export default class Universal extends Task {
     public type: string = 'universal';
     public id: string;
     public tower: StructureTower;
-    public targets: any[];
 
     constructor(id: string, tower: StructureTower) {
         super();
         this.id = id;
         this.tower = tower;
-        this.targets = tower.room.find(FIND_STRUCTURES).filter(s => s.structureType === STRUCTURE_CONTAINER);
     }
 
     public run(): void {
         if (this.tower.energy > 10) {
-            this.collectEnergy();
+            this.spendEnergy();
         }
     }
 
-    public collectEnergy(): void {
-        /** no op */
-    }
+    private spendEnergy(): void {
+        // TODO: This is likely an expensive call, but its important to do this very frequently. Can we figure out a better way?
+        const enemies = this.tower.room.find(FIND_HOSTILE_CREEPS);
+        if (enemies.length > 0) {
+            const sorted = enemies.sort((a, b) => a.hits - b.hits);
+            this.tower.attack(sorted[0]);
+            return;
+        }
 
-    public dropOffEnergy(): void {
-        /** no op */
+        const wounded = this.tower.room.find(FIND_MY_CREEPS, {filter: (e) => e.hits < e.hitsMax});
+        if (wounded.length > 0) {
+            const sorted = wounded.sort((a, b) => a.hits - b.hits);
+            this.tower.heal(sorted[0]);
+            return;
+        }
+
+        const damaged = this.tower.room.find(FIND_MY_STRUCTURES, {filter: (e) => e.hits < e.hitsMax});
+        if (damaged.length > 0) {
+            const sorted = damaged.sort((a, b) => a.hits - b.hits);
+            this.tower.repair(sorted[0]);
+            return;
+        }
     }
 }


### PR DESCRIPTION
## Why?

Towers weren't doing anything!

## What?
- Modified tower logic so that the universal task will attack, heal, and repair in that order of priority.
- Modified the scheduler so it will schedule tower tasks.

## Shower Thoughts?
- Should the scheduler call static methods on the task to determine if they should even be queued up? This would simplify the scheduler and allow tasks to determine if they should/shouldn't be scheduled.